### PR TITLE
Ensuring check for empty character does not include "0" in ord method.

### DIFF
--- a/src/voku/helper/UTF8.php
+++ b/src/voku/helper/UTF8.php
@@ -3919,7 +3919,7 @@ class UTF8
    */
   public static function ord($s)
   {
-    if (!$s) {
+    if (!$s  && $s !== "0") {
       return 0;
     }
 


### PR DESCRIPTION
UTF8::ord("0") incorrectly returns 0 as the ordinal. This change corrects that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/portable-utf8/31)
<!-- Reviewable:end -->
