### PR TITLE
trim('0002', '0') returns '0002'

### DIFF
--- a/src/voku/helper/UTF8.php
+++ b/src/voku/helper/UTF8.php
@@ -4604,7 +4604,7 @@ final class UTF8
         }
 
         if (self::$SUPPORT['mbstring'] === true) {
-            if ($chars) {
+            if ($chars !== null) {
                 /** @noinspection PregQuoteUsageInspection */
                 $chars = \preg_quote($chars);
                 $pattern = "^[${chars}]+";
@@ -4616,7 +4616,7 @@ final class UTF8
             return (string) \mb_ereg_replace($pattern, '', $str);
         }
 
-        if ($chars) {
+        if ($chars !== null) {
             $chars = \preg_quote($chars, '/');
             $pattern = "^[${chars}]+";
         } else {
@@ -5685,7 +5685,7 @@ final class UTF8
         }
 
         if (self::$SUPPORT['mbstring'] === true) {
-            if ($chars) {
+            if ($chars !== null) {
                 /** @noinspection PregQuoteUsageInspection */
                 $chars = \preg_quote($chars);
                 $pattern = "[${chars}]+$";
@@ -5697,7 +5697,7 @@ final class UTF8
             return (string) \mb_ereg_replace($pattern, '', $str);
         }
 
-        if ($chars) {
+        if ($chars !== null) {
             $chars = \preg_quote($chars, '/');
             $pattern = "[${chars}]+$";
         } else {
@@ -13168,7 +13168,7 @@ final class UTF8
         }
 
         if (self::$SUPPORT['mbstring'] === true) {
-            if ($chars) {
+            if ($chars !== null) {
                 /** @noinspection PregQuoteUsageInspection */
                 $chars = \preg_quote($chars);
                 $pattern = "^[${chars}]+|[${chars}]+\$";
@@ -13180,7 +13180,7 @@ final class UTF8
             return (string) \mb_ereg_replace($pattern, '', $str);
         }
 
-        if ($chars) {
+        if ($chars !== null) {
             $chars = \preg_quote($chars, '/');
             $pattern = "^[${chars}]+|[${chars}]+\$";
         } else {

--- a/tests/Utf8LtrimTest.php
+++ b/tests/Utf8LtrimTest.php
@@ -87,4 +87,12 @@ final class Utf8LtrimTest extends \PHPUnit\Framework\TestCase
         static::assertSame($trimmed, u::ltrim($str, "ñ\n"));
         static::assertSame($trimmed, \ltrim($str, "ñ\n"));
     }
+
+    public function testLtrimWithCharacter0()
+    {
+        $str = "007";
+        $trimmed = '7';
+        static::assertSame($trimmed, u::ltrim($str, "0"));
+        static::assertSame($trimmed, \ltrim($str, "0"));
+    }
 }

--- a/tests/Utf8LtrimTest.php
+++ b/tests/Utf8LtrimTest.php
@@ -90,9 +90,9 @@ final class Utf8LtrimTest extends \PHPUnit\Framework\TestCase
 
     public function testLtrimWithCharacter0()
     {
-        $str = "007";
+        $str = '007';
         $trimmed = '7';
-        static::assertSame($trimmed, u::ltrim($str, "0"));
-        static::assertSame($trimmed, \ltrim($str, "0"));
+        static::assertSame($trimmed, u::ltrim($str, '0'));
+        static::assertSame($trimmed, \ltrim($str, '0'));
     }
 }

--- a/tests/Utf8RtrimTest.php
+++ b/tests/Utf8RtrimTest.php
@@ -61,4 +61,12 @@ final class Utf8RtrimTest extends \PHPUnit\Framework\TestCase
         static::assertSame($trimmed, u::rtrim($str, "ø\n"));
         static::assertSame($trimmed, \rtrim($str, "ø\n"));
     }
+
+    public function testRtrimWithCharacter0()
+    {
+        $str = "00700";
+        $trimmed = '007';
+        static::assertSame($trimmed, u::rtrim($str, "0"));
+        static::assertSame($trimmed, \rtrim($str, "0"));
+    }
 }

--- a/tests/Utf8RtrimTest.php
+++ b/tests/Utf8RtrimTest.php
@@ -64,9 +64,9 @@ final class Utf8RtrimTest extends \PHPUnit\Framework\TestCase
 
     public function testRtrimWithCharacter0()
     {
-        $str = "00700";
+        $str = '00700';
         $trimmed = '007';
-        static::assertSame($trimmed, u::rtrim($str, "0"));
-        static::assertSame($trimmed, \rtrim($str, "0"));
+        static::assertSame($trimmed, u::rtrim($str, '0'));
+        static::assertSame($trimmed, \rtrim($str, '0'));
     }
 }

--- a/tests/Utf8TrimTest.php
+++ b/tests/Utf8TrimTest.php
@@ -33,4 +33,11 @@ final class Utf8TrimTest extends \PHPUnit\Framework\TestCase
         $trimmed = '';
         static::assertSame($trimmed, u::trim($str));
     }
+
+    public function testTrimWithCharacter0()
+    {
+        $str = "00700";
+        $trimmed = '7';
+        static::assertSame($trimmed, u::trim($str, "0"));
+    }
 }

--- a/tests/Utf8TrimTest.php
+++ b/tests/Utf8TrimTest.php
@@ -36,8 +36,8 @@ final class Utf8TrimTest extends \PHPUnit\Framework\TestCase
 
     public function testTrimWithCharacter0()
     {
-        $str = "00700";
+        $str = '00700';
         $trimmed = '7';
-        static::assertSame($trimmed, u::trim($str, "0"));
+        static::assertSame($trimmed, u::trim($str, '0'));
     }
 }


### PR DESCRIPTION
`trim('0002', '0')`
- returns '0002'
- expected is '2'

Problem in code is:
`(bool)('0') is false`

the same problem is in **ltrim** and **rtrim**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/portable-utf8/98)
<!-- Reviewable:end -->
