### PR TITLE
Use ENT_HTML401 to decode numeric entities

### DIFF
--- a/src/voku/helper/UTF8.php
+++ b/src/voku/helper/UTF8.php
@@ -1218,7 +1218,9 @@ final class UTF8
      */
     public static function decimal_to_chr($int): string
     {
-        return self::html_entity_decode('&#' . $int . ';', \ENT_QUOTES | \ENT_HTML5);
+        // We cannot use ENT_HTML5 here, as carriage return (&#13;) is not
+        // a valid numeric entity with that document type.
+        return self::html_entity_decode('&#' . $int . ';', \ENT_QUOTES | \ENT_HTML401);
     }
 
     /**
@@ -9926,7 +9928,9 @@ final class UTF8
             $str .= '&#' . (int) $strPart . ';';
         }
 
-        return self::html_entity_decode($str, \ENT_QUOTES | \ENT_HTML5);
+        // We cannot use ENT_HTML5 here, as carriage return (&#13;) is not
+        // a valid numeric entity with that document type.
+        return self::html_entity_decode($str, \ENT_QUOTES | \ENT_HTML401);
     }
 
     /**


### PR DESCRIPTION
ENT_HTML5 will not decode the numeric entity for a carriage return.
Use ENT_HTML401 to correctly decide all numeric entities.

**Fixes** https://github.com/voku/portable-utf8/issues/104

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/portable-utf8/105)
<!-- Reviewable:end -->
