### PR TITLE
Use mb_convert_encoding() for character conversion

### DIFF
--- a/src/voku/helper/UTF8.php
+++ b/src/voku/helper/UTF8.php
@@ -1218,7 +1218,9 @@ final class UTF8
      */
     public static function decimal_to_chr($int): string
     {
-        return self::html_entity_decode('&#' . $int . ';', \ENT_QUOTES | \ENT_HTML5);
+        // We cannot use html_entity_decode() here, as it will not return
+        // characters for many values < 160.
+        return mb_convert_encoding('&#' . $int . ';', 'UTF-8', 'HTML-ENTITIES');
     }
 
     /**
@@ -9926,7 +9928,9 @@ final class UTF8
             $str .= '&#' . (int) $strPart . ';';
         }
 
-        return self::html_entity_decode($str, \ENT_QUOTES | \ENT_HTML5);
+        // We cannot use html_entity_decode() here, as it will not return
+        // characters for many values < 160.
+        return mb_convert_encoding($str, 'UTF-8', 'HTML-ENTITIES');
     }
 
     /**


### PR DESCRIPTION
`html_entity_decode()` will not decode characters for many values < 160, most notably 0-31 and 127-159. `mb_convert_encoding()` correctly decodes these values.

**Fixes** https://github.com/voku/portable-utf8/issues/104

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/portable-utf8/106)
<!-- Reviewable:end -->
