### PR TITLE
Minor improvements in UTF8::levenshtein()

### DIFF
--- a/src/voku/helper/UTF8.php
+++ b/src/voku/helper/UTF8.php
@@ -4334,6 +4334,8 @@ final class UTF8
      * @param  integer $deletionCost    [optional] <p>Defines the cost of deletion.</p>
      *
      * @return int
+     *             <p>Returns the Levenshtein-Distance between the two argument strings or -1,<br>
+     *             if one of the argument strings is longer than the limit of 255 characters.</p>
      */
     public static function levenshtein(
         string $str1,
@@ -4342,6 +4344,10 @@ final class UTF8
         int $replacementCost = 1,
         int $deletionCost = 1
     ): int {
+        if ($str1 === $str2) {
+            return 0;
+        }
+
         $result = ASCII::to_ascii_remap($str1, $str2);
 
         return \levenshtein($result[0], $result[1], $insertionCost, $replacementCost, $deletionCost);

--- a/tests/Utf8LevenshteinTest.php
+++ b/tests/Utf8LevenshteinTest.php
@@ -137,6 +137,7 @@ final class Utf8LevenshteinTest extends \PHPUnit\Framework\TestCase
         static::assertSame(0, UTF8::levenshtein('', '', 1));
         static::assertSame(0, UTF8::levenshtein('', '', 1, 2));
         static::assertSame(0, UTF8::levenshtein('', '', 1, 2, 3));
+        static::assertSame(0, UTF8::levenshtein('', '', 3, 2, 1));
     }
 
     public function testLargeStrings()
@@ -155,5 +156,10 @@ final class Utf8LevenshteinTest extends \PHPUnit\Framework\TestCase
             $this->expectException(\PHPUnit\Framework\Error\Warning::class);
             UTF8::levenshtein('ё', $longString);
         }
+    }
+
+    public function testEqualStrings()
+    {
+        static::assertSame(0, UTF8::levenshtein('厕所在哪里', '厕所在哪里'));
     }
 }


### PR DESCRIPTION
#### Proposed Changes
* Minor optimization in `UTF8::levenshtein()`: immediately return `0` on totally equal strings
* Add test-case for equal strings
* Add missed `@return` PHPDoc description