### PR TITLE
[PHP 8.2] Fix `${var}` string interpolation deprecation

### DIFF
--- a/src/voku/helper/UTF8.php
+++ b/src/voku/helper/UTF8.php
@@ -4386,7 +4386,7 @@ final class UTF8
             if ($chars !== null) {
                 /** @noinspection PregQuoteUsageInspection */
                 $chars = \preg_quote($chars);
-                $pattern = "^[${chars}]+";
+                $pattern = "^[{$chars}]+";
             } else {
                 $pattern = '^[\\s]+';
             }
@@ -4396,7 +4396,7 @@ final class UTF8
 
         if ($chars !== null) {
             $chars = \preg_quote($chars, '/');
-            $pattern = "^[${chars}]+";
+            $pattern = "^[{$chars}]+";
         } else {
             $pattern = '^[\\s]+';
         }
@@ -5418,7 +5418,7 @@ final class UTF8
             if ($chars !== null) {
                 /** @noinspection PregQuoteUsageInspection */
                 $chars = \preg_quote($chars);
-                $pattern = "[${chars}]+$";
+                $pattern = "[{$chars}]+$";
             } else {
                 $pattern = '[\\s]+$';
             }
@@ -5428,7 +5428,7 @@ final class UTF8
 
         if ($chars !== null) {
             $chars = \preg_quote($chars, '/');
-            $pattern = "[${chars}]+$";
+            $pattern = "[{$chars}]+$";
         } else {
             $pattern = '[\\s]+$';
         }
@@ -12629,7 +12629,7 @@ final class UTF8
             if ($chars !== null) {
                 /** @noinspection PregQuoteUsageInspection */
                 $chars = \preg_quote($chars);
-                $pattern = "^[${chars}]+|[${chars}]+\$";
+                $pattern = "^[{$chars}]+|[{$chars}]+\$";
             } else {
                 $pattern = '^[\\s]+|[\\s]+$';
             }
@@ -12639,7 +12639,7 @@ final class UTF8
 
         if ($chars !== null) {
             $chars = \preg_quote($chars, '/');
-            $pattern = "^[${chars}]+|[${chars}]+\$";
+            $pattern = "^[{$chars}]+|[{$chars}]+\$";
         } else {
             $pattern = '^[\\s]+|[\\s]+$';
         }


### PR DESCRIPTION
PHP 8.2 deprecates `"${var}"` string interpolation pattern.
This fixes all 8 of such occurrences in `voku/portable-utf8` package.

 - [PHP 8.2: `${var}` string interpolation deprecated](https://php.watch/versions/8.2/${var}-string-interpolation-deprecated)
 - [RFC](https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/portable-utf8/181)
<!-- Reviewable:end -->
