### PR TITLE
Swap ${ for {$ for PHP 8.2 deprecation

### DIFF
--- a/src/voku/helper/UTF8.php
+++ b/src/voku/helper/UTF8.php
@@ -4650,7 +4650,7 @@ final class UTF8
             if ($chars !== null) {
                 /** @noinspection PregQuoteUsageInspection */
                 $chars = \preg_quote($chars);
-                $pattern = "^[${chars}]+";
+                $pattern = "^[{$chars}]+";
             } else {
                 $pattern = '^[\\s]+';
             }
@@ -4661,7 +4661,7 @@ final class UTF8
 
         if ($chars !== null) {
             $chars = \preg_quote($chars, '/');
-            $pattern = "^[${chars}]+";
+            $pattern = "^[{$chars}]+";
         } else {
             $pattern = '^[\\s]+';
         }
@@ -5728,7 +5728,7 @@ final class UTF8
             if ($chars !== null) {
                 /** @noinspection PregQuoteUsageInspection */
                 $chars = \preg_quote($chars);
-                $pattern = "[${chars}]+$";
+                $pattern = "[{$chars}]+$";
             } else {
                 $pattern = '[\\s]+$';
             }
@@ -5739,7 +5739,7 @@ final class UTF8
 
         if ($chars !== null) {
             $chars = \preg_quote($chars, '/');
-            $pattern = "[${chars}]+$";
+            $pattern = "[{$chars}]+$";
         } else {
             $pattern = '[\\s]+$';
         }
@@ -13395,7 +13395,7 @@ final class UTF8
             if ($chars !== null) {
                 /** @noinspection PregQuoteUsageInspection */
                 $chars = \preg_quote($chars);
-                $pattern = "^[${chars}]+|[${chars}]+\$";
+                $pattern = "^[{$chars}]+|[{$chars}]+\$";
             } else {
                 $pattern = '^[\\s]+|[\\s]+$';
             }
@@ -13406,7 +13406,7 @@ final class UTF8
 
         if ($chars !== null) {
             $chars = \preg_quote($chars, '/');
-            $pattern = "^[${chars}]+|[${chars}]+\$";
+            $pattern = "^[{$chars}]+|[{$chars}]+\$";
         } else {
             $pattern = '^[\\s]+|[\\s]+$';
         }


### PR DESCRIPTION
**Fixes** #191 

#### Proposed Changes
* Just changes `${ to {$` to make PHP 8.2 shut up about deprecations. :)

####
Needs to be backported to v5

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/portable-utf8/193)
<!-- Reviewable:end -->
