### PR TITLE
fix for E_DEPRECATED:  Implicit conversion from float 3.984375 to int…

### DIFF
--- a/src/voku/helper/UTF8.php
+++ b/src/voku/helper/UTF8.php
@@ -14059,7 +14059,7 @@ final class UTF8
         if (isset(self::$WIN1252_TO_UTF8[$ordC1])) { // found in Windows-1252 special cases
             $buf .= self::$WIN1252_TO_UTF8[$ordC1];
         } else {
-            $cc1 = self::$CHR[$ordC1 / 64] | "\xC0";
+            $cc1 = self::$CHR[intval(floor($ordC1 / 64))] | "\xC0";
             $cc2 = ((string) $input & "\x3F") | "\x80";
             $buf .= $cc1 . $cc2;
         }


### PR DESCRIPTION
… loses precision

**Fixes** #
a float that is converted to int, and in php8.1 that is DEPRECATED:

https://wiki.php.net/rfc/implicit-float-int-deprecate