### PR TITLE
Removed incorrect annotation from class

### DIFF
--- a/src/voku/helper/Bootup.php
+++ b/src/voku/helper/Bootup.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace voku\helper;
 
-/**
- * @psalm-immutable
- */
 class Bootup
 {
     /**


### PR DESCRIPTION
`get_random_bytes` is not immutable. The psalm docs explicitly call this out: https://psalm.dev/docs/annotating_code/supported_annotations/#psalm-mutation-free.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/portable-utf8/198)
<!-- Reviewable:end -->
