### PR TITLE
php 8.4 deprecation message

### DIFF
--- a/src/voku/helper/UTF8.php
+++ b/src/voku/helper/UTF8.php
@@ -1621,7 +1621,7 @@ final class UTF8
     public static function extract_text(
         string $str,
         string $search = '',
-        int $length = null,
+        ?int $length = null,
         string $replacer_for_skipped_text = '…',
         string $encoding = 'UTF-8'
     ): string {
@@ -1842,8 +1842,8 @@ final class UTF8
         string $filename,
         bool $use_include_path = false,
         $context = null,
-        int $offset = null,
-        int $max_length = null,
+        ?int $offset = null,
+        ?int $max_length = null,
         int $timeout = 10,
         bool $convert_to_utf8 = true,
         string $from_encoding = ''
@@ -2576,7 +2576,7 @@ final class UTF8
      *               return bool-value, if $key is used and available<br>
      *               otherwise return <strong>null</strong>
      */
-    public static function getSupportInfo(string $key = null)
+    public static function getSupportInfo(?string $key = null)
     {
         if ($key === null) {
             return self::$SUPPORT;
@@ -3027,7 +3027,7 @@ final class UTF8
      */
     public static function html_entity_decode(
         string $str,
-        int $flags = null,
+        ?int $flags = null,
         string $encoding = 'UTF-8'
     ): string {
         if (
@@ -4301,7 +4301,7 @@ final class UTF8
         string $str,
         string $encoding = 'UTF-8',
         bool $clean_utf8 = false,
-        string $lang = null,
+        ?string $lang = null,
         bool $try_to_keep_the_string_length = false
     ): string {
         if ($clean_utf8) {
@@ -4367,7 +4367,7 @@ final class UTF8
         string $char_list = '',
         string $encoding = 'UTF-8',
         bool $clean_utf8 = false,
-        string $lang = null,
+        ?string $lang = null,
         bool $try_to_keep_the_string_length = false
     ): string {
         if (!$str) {
@@ -4440,7 +4440,7 @@ final class UTF8
      *
      * @return string the string with unwanted characters stripped from the left
      */
-    public static function ltrim(string $str = '', string $chars = null): string
+    public static function ltrim(string $str = '', ?string $chars = null): string
     {
         if ($str === '') {
             return '';
@@ -5621,7 +5621,7 @@ final class UTF8
      * @return string
      *                <p>A string with unwanted characters stripped from the right.</p>
      */
-    public static function rtrim(string $str = '', string $chars = null): string
+    public static function rtrim(string $str = '', ?string $chars = null): string
     {
         if ($str === '') {
             return '';
@@ -5762,7 +5762,7 @@ final class UTF8
         string $str,
         string $encoding = 'UTF-8',
         bool $clean_utf8 = false,
-        string $lang = null,
+        ?string $lang = null,
         bool $try_to_keep_the_string_length = false
     ): string {
         if ($clean_utf8) {
@@ -6023,7 +6023,7 @@ final class UTF8
         string $delimiter,
         string $encoding = 'UTF-8',
         bool $clean_utf8 = false,
-        string $lang = null,
+        ?string $lang = null,
         bool $try_to_keep_the_string_length = false
     ): string {
         if (self::$SUPPORT['mbstring'] === true) {
@@ -7678,7 +7678,7 @@ final class UTF8
         $search,
         $replace,
         $subject,
-        int &$count = null
+        ?int &$count = null
     ) {
         /**
          * @psalm-suppress PossiblyNullArgument
@@ -7912,7 +7912,7 @@ final class UTF8
     public static function str_slice(
         string $str,
         int $start,
-        int $end = null,
+        ?int $end = null,
         string $encoding = 'UTF-8'
     ) {
         if ($encoding === 'UTF-8') {
@@ -8701,13 +8701,13 @@ final class UTF8
      */
     public static function str_titleize(
         string $str,
-        array $ignore = null,
+        ?array $ignore = null,
         string $encoding = 'UTF-8',
         bool $clean_utf8 = false,
-        string $lang = null,
+        ?string $lang = null,
         bool $try_to_keep_the_string_length = false,
         bool $use_trim_first = true,
-        string $word_define_chars = null
+        ?string $word_define_chars = null
     ): string {
         if ($str === '') {
             return '';
@@ -9059,7 +9059,7 @@ final class UTF8
      *
      * @return string[]
      */
-    public static function str_to_lines(string $str, bool $remove_empty_values = false, int $remove_short_values = null): array
+    public static function str_to_lines(string $str, bool $remove_empty_values = false, ?int $remove_short_values = null): array
     {
         if ($str === '') {
             return $remove_empty_values ? [] : [''];
@@ -9110,7 +9110,7 @@ final class UTF8
         string $str,
         string $char_list = '',
         bool $remove_empty_values = false,
-        int $remove_short_values = null
+        ?int $remove_short_values = null
     ): array {
         if ($str === '') {
             return $remove_empty_values ? [] : [''];
@@ -9351,7 +9351,7 @@ final class UTF8
         string $str,
         string $encoding = 'UTF-8',
         bool $clean_utf8 = false,
-        string $lang = null,
+        ?string $lang = null,
         bool $try_to_keep_the_string_length = false
     ): string {
         return self::ucfirst(self::str_camelize($str, $encoding), $encoding, $clean_utf8, $lang, $try_to_keep_the_string_length);
@@ -9514,7 +9514,7 @@ final class UTF8
         string $str,
         string $char_list,
         int $offset = 0,
-        int $length = null,
+        ?int $length = null,
         string $encoding = 'UTF-8'
     ): int {
         if ($encoding !== 'UTF-8' && $encoding !== 'CP850') {
@@ -9649,7 +9649,7 @@ final class UTF8
      */
     public static function strip_tags(
         string $str,
-        string $allowable_tags = null,
+        ?string $allowable_tags = null,
         bool $clean_utf8 = false
     ): string {
         if ($str === '') {
@@ -11117,7 +11117,7 @@ final class UTF8
         string $str,
         string $mask,
         int $offset = 0,
-        int $length = null,
+        ?int $length = null,
         string $encoding = 'UTF-8'
     ) {
         if ($encoding !== 'UTF-8' && $encoding !== 'CP850') {
@@ -11348,7 +11348,7 @@ final class UTF8
         bool $full = true,
         bool $clean_utf8 = false,
         string $encoding = 'UTF-8',
-        string $lang = null,
+        ?string $lang = null,
         bool $lower = true
     ): string {
         if ($str === '') {
@@ -11402,7 +11402,7 @@ final class UTF8
         $str,
         string $encoding = 'UTF-8',
         bool $clean_utf8 = false,
-        string $lang = null,
+        ?string $lang = null,
         bool $try_to_keep_the_string_length = false
     ): string {
         // init
@@ -11482,7 +11482,7 @@ final class UTF8
         $str,
         string $encoding = 'UTF-8',
         bool $clean_utf8 = false,
-        string $lang = null,
+        ?string $lang = null,
         bool $try_to_keep_the_string_length = false
     ): string {
         // init
@@ -11696,7 +11696,7 @@ final class UTF8
     public static function substr(
         string $str,
         int $offset = 0,
-        int $length = null,
+        ?int $length = null,
         string $encoding = 'UTF-8',
         bool $clean_utf8 = false
     ) {
@@ -11867,7 +11867,7 @@ final class UTF8
         string $str1,
         string $str2,
         int $offset = 0,
-        int $length = null,
+        ?int $length = null,
         bool $case_insensitivity = false,
         string $encoding = 'UTF-8'
     ): int {
@@ -11925,7 +11925,7 @@ final class UTF8
         string $haystack,
         string $needle,
         int $offset = 0,
-        int $length = null,
+        ?int $length = null,
         string $encoding = 'UTF-8',
         bool $clean_utf8 = false
     ) {
@@ -12017,7 +12017,7 @@ final class UTF8
         string $haystack,
         string $needle,
         int $offset = 0,
-        int $length = null
+        ?int $length = null
     ) {
         if ($haystack === '' || $needle === '') {
             return 0;
@@ -12167,7 +12167,7 @@ final class UTF8
      *                      <i>length</i> parameters.</p><p>If <i>str</i> is shorter than <i>offset</i>
      *                      characters long, <b>FALSE</b> will be returned.</p>
      */
-    public static function substr_in_byte(string $str, int $offset = 0, int $length = null)
+    public static function substr_in_byte(string $str, int $offset = 0, ?int $length = null)
     {
         // empty string
         if ($str === '' || $length === 0) {
@@ -12565,7 +12565,7 @@ final class UTF8
         string $str,
         string $encoding = 'UTF-8',
         bool $clean_utf8 = false,
-        string $lang = null,
+        ?string $lang = null,
         bool $try_to_keep_the_string_length = false
     ): string {
         if ($clean_utf8) {
@@ -12972,7 +12972,7 @@ final class UTF8
      * @return string
      *                <p>The trimmed string.</p>
      */
-    public static function trim(string $str = '', string $chars = null): string
+    public static function trim(string $str = '', ?string $chars = null): string
     {
         if ($str === '') {
             return '';
@@ -13022,7 +13022,7 @@ final class UTF8
         string $str,
         string $encoding = 'UTF-8',
         bool $clean_utf8 = false,
-        string $lang = null,
+        ?string $lang = null,
         bool $try_to_keep_the_string_length = false
     ): string {
         if ($str === '') {
@@ -13490,7 +13490,7 @@ final class UTF8
         string $break = "\n",
         bool $cut = false,
         bool $add_final_break = true,
-        string $delimiter = null
+        ?string $delimiter = null
     ): string {
         if ($delimiter === null) {
             $strings = \preg_split('/\\r\\n|\\r|\\n/', $str);
@@ -13801,8 +13801,8 @@ final class UTF8
         /** @noinspection PhpUsageOfSilenceOperatorInspection */
         /** @noinspection DeprecatedIniOptionsInspection */
         return \defined('MB_OVERLOAD_STRING')
-               &&
-               ((int) @\ini_get('mbstring.func_overload') & \MB_OVERLOAD_STRING);
+            &&
+            ((int) @\ini_get('mbstring.func_overload') & \MB_OVERLOAD_STRING);
     }
 
     /**
@@ -13817,7 +13817,7 @@ final class UTF8
     private static function reduce_string_array(
         array $strings,
         bool $remove_empty_values,
-        int $remove_short_values = null
+        ?int $remove_short_values = null
     ) {
         // init
         $return = [];


### PR DESCRIPTION
Fixes: PHP 8.4 Deprecated messages 

More info: https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/portable-utf8/215)
<!-- Reviewable:end -->
