### PR TITLE
Regenerate README after build update

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ The API from the "UTF8"-Class is written as small static methods that will match
 </td></tr><tr><td><a href="#getchardirectionstring-char-string">getCharDirection</a>
 </td><td><a href="#getsupportinfostringnull-key-mixed">getSupportInfo</a>
 </td><td><a href="#geturlparamfromarraystring-param-array-data-mixed">getUrlParamFromArray</a>
-</td><td><a href="#get_file_typestring-str-array-fallback">get_file_type</a>
+</td><td><a href="#get_file_typestring-str-arrayext-nullstring-mime-nullstring-type-nullstring-fallback-arrayext-nullstring-mime-nullstring-type-nullstring">get_file_type</a>
 </td></tr><tr><td><a href="#get_random_stringint-length-string-possible_chars-string-encoding-string">get_random_string</a>
 </td><td><a href="#get_unique_stringintstring-extra_entropy-bool-use_md5-non-empty-string">get_unique_string</a>
 </td><td><a href="#has_lowercasestring-str-bool">has_lowercase</a>
@@ -314,114 +314,115 @@ The API from the "UTF8"-Class is written as small static methods that will match
 </td><td><a href="#str_last_charstring-str-int-n-string-encoding-string">str_last_char</a>
 </td><td><a href="#str_limitstring-str-int-length-string-str_add_on-string-encoding-string">str_limit</a>
 </td></tr><tr><td><a href="#str_limit_after_wordstring-str-int-length-string-str_add_on-string-encoding-string">str_limit_after_word</a>
+</td><td><a href="#str_limit_in_bytestring-str-int-length-string-str_add_on-string-encoding-string">str_limit_in_byte</a>
 </td><td><a href="#str_longest_common_prefixstring-str1-string-str2-string-encoding-string">str_longest_common_prefix</a>
 </td><td><a href="#str_longest_common_substringstring-str1-string-str2-string-encoding-string">str_longest_common_substring</a>
-</td><td><a href="#str_longest_common_suffixstring-str1-string-str2-string-encoding-string">str_longest_common_suffix</a>
-</td></tr><tr><td><a href="#str_matches_patternstring-str-string-pattern-bool">str_matches_pattern</a>
+</td></tr><tr><td><a href="#str_longest_common_suffixstring-str1-string-str2-string-encoding-string">str_longest_common_suffix</a>
+</td><td><a href="#str_matches_patternstring-str-string-pattern-bool">str_matches_pattern</a>
 </td><td><a href="#str_obfuscatestring-str-float-percent-string-obfuscatechar-string-keepchars-string">str_obfuscate</a>
 </td><td><a href="#str_offset_existsstring-str-int-offset-string-encoding-bool">str_offset_exists</a>
-</td><td><a href="#str_offset_getstring-str-int-index-string-encoding-string">str_offset_get</a>
-</td></tr><tr><td><a href="#str_padstring-str-int-pad_length-string-pad_string-intstring-pad_type-string-encoding-string">str_pad</a>
+</td></tr><tr><td><a href="#str_offset_getstring-str-int-index-string-encoding-string">str_offset_get</a>
+</td><td><a href="#str_padstring-str-int-pad_length-string-pad_string-intstring-pad_type-string-encoding-string">str_pad</a>
 </td><td><a href="#str_pad_bothstring-str-int-length-string-pad_str-string-encoding-string">str_pad_both</a>
 </td><td><a href="#str_pad_leftstring-str-int-length-string-pad_str-string-encoding-string">str_pad_left</a>
-</td><td><a href="#str_pad_rightstring-str-int-length-string-pad_str-string-encoding-string">str_pad_right</a>
-</td></tr><tr><td><a href="#str_repeatstring-str-int-multiplier-string">str_repeat</a>
+</td></tr><tr><td><a href="#str_pad_rightstring-str-int-length-string-pad_str-string-encoding-string">str_pad_right</a>
+</td><td><a href="#str_repeatstring-str-int-multiplier-string">str_repeat</a>
 </td><td><a href="#str_replace_beginningstring-str-string-search-string-replacement-string">str_replace_beginning</a>
 </td><td><a href="#str_replace_endingstring-str-string-search-string-replacement-string">str_replace_ending</a>
-</td><td><a href="#str_replace_firststring-search-string-replace-string-subject-string">str_replace_first</a>
-</td></tr><tr><td><a href="#str_replace_laststring-search-string-replace-string-subject-string">str_replace_last</a>
+</td></tr><tr><td><a href="#str_replace_firststring-search-string-replace-string-subject-string">str_replace_first</a>
+</td><td><a href="#str_replace_laststring-search-string-replace-string-subject-string">str_replace_last</a>
 </td><td><a href="#str_shufflestring-str-string-encoding-string">str_shuffle</a>
 </td><td><a href="#str_slicestring-str-int-start-intnull-end-string-encoding-falsestring">str_slice</a>
-</td><td><a href="#str_snakeizestring-str-string-encoding-string">str_snakeize</a>
-</td></tr><tr><td><a href="#str_sortstring-str-bool-unique-bool-desc-string">str_sort</a>
+</td></tr><tr><td><a href="#str_snakeizestring-str-string-encoding-string">str_snakeize</a>
+</td><td><a href="#str_sortstring-str-bool-unique-bool-desc-string">str_sort</a>
 </td><td><a href="#str_splitintstring-str-int-length-bool-clean_utf8-bool-try_to_use_mb_functions-liststring">str_split</a>
 </td><td><a href="#str_split_arrayintstring-input-int-length-bool-clean_utf8-bool-try_to_use_mb_functions-listliststring">str_split_array</a>
-</td><td><a href="#str_split_patternstring-str-string-pattern-int-limit-string">str_split_pattern</a>
-</td></tr><tr><td><a href="#str_starts_withstring-haystack-string-needle-bool">str_starts_with</a>
+</td></tr><tr><td><a href="#str_split_patternstring-str-string-pattern-int-limit-string">str_split_pattern</a>
+</td><td><a href="#str_starts_withstring-haystack-string-needle-bool">str_starts_with</a>
 </td><td><a href="#str_starts_with_anystring-str-scalar-substrings-bool">str_starts_with_any</a>
 </td><td><a href="#str_substr_after_first_separatorstring-str-string-separator-string-encoding-string">str_substr_after_first_separator</a>
-</td><td><a href="#str_substr_after_last_separatorstring-str-string-separator-string-encoding-string">str_substr_after_last_separator</a>
-</td></tr><tr><td><a href="#str_substr_before_first_separatorstring-str-string-separator-string-encoding-string">str_substr_before_first_separator</a>
+</td></tr><tr><td><a href="#str_substr_after_last_separatorstring-str-string-separator-string-encoding-string">str_substr_after_last_separator</a>
+</td><td><a href="#str_substr_before_first_separatorstring-str-string-separator-string-encoding-string">str_substr_before_first_separator</a>
 </td><td><a href="#str_substr_before_last_separatorstring-str-string-separator-string-encoding-string">str_substr_before_last_separator</a>
 </td><td><a href="#str_substr_firststring-str-string-needle-bool-before_needle-string-encoding-string">str_substr_first</a>
-</td><td><a href="#str_substr_laststring-str-string-needle-bool-before_needle-string-encoding-string">str_substr_last</a>
-</td></tr><tr><td><a href="#str_surroundstring-str-string-substring-string">str_surround</a>
+</td></tr><tr><td><a href="#str_substr_laststring-str-string-needle-bool-before_needle-string-encoding-string">str_substr_last</a>
+</td><td><a href="#str_surroundstring-str-string-substring-string">str_surround</a>
 </td><td><a href="#str_titleizestring-str-stringnull-ignore-string-encoding-bool-clean_utf8-stringnull-lang-bool-try_to_keep_the_string_length-bool-use_trim_first-stringnull-word_define_chars-string">str_titleize</a>
 </td><td><a href="#str_titleize_for_humansstring-str-string-ignore-string-encoding-string">str_titleize_for_humans</a>
-</td><td><a href="#str_to_binarystring-str-falsestring">str_to_binary</a>
-</td></tr><tr><td><a href="#str_to_linesstring-str-bool-remove_empty_values-intnull-remove_short_values-string">str_to_lines</a>
+</td></tr><tr><td><a href="#str_to_binarystring-str-falsestring">str_to_binary</a>
+</td><td><a href="#str_to_linesstring-str-bool-remove_empty_values-intnull-remove_short_values-string">str_to_lines</a>
 </td><td><a href="#str_to_wordsstring-str-string-char_list-bool-remove_empty_values-intnull-remove_short_values-liststring">str_to_words</a>
 </td><td><a href="#str_truncatestring-str-int-length-string-substring-string-encoding-string">str_truncate</a>
-</td><td><a href="#str_truncate_safestring-str-int-length-string-substring-string-encoding-bool-ignore_do_not_split_words_for_one_word-string">str_truncate_safe</a>
-</td></tr><tr><td><a href="#str_underscoredstring-str-string">str_underscored</a>
+</td></tr><tr><td><a href="#str_truncate_safestring-str-int-length-string-substring-string-encoding-bool-ignore_do_not_split_words_for_one_word-string">str_truncate_safe</a>
+</td><td><a href="#str_underscoredstring-str-string">str_underscored</a>
 </td><td><a href="#str_upper_camelizestring-str-string-encoding-bool-clean_utf8-stringnull-lang-bool-try_to_keep_the_string_length-string">str_upper_camelize</a>
 </td><td><a href="#str_word_countstring-str-int-format-string-char_list-intstring">str_word_count</a>
-</td><td><a href="#strcasecmpstring-str1-string-str2-string-encoding-int">strcasecmp</a>
-</td></tr><tr><td><a href="#strcmpstring-str1-string-str2-int">strcmp</a>
+</td></tr><tr><td><a href="#strcasecmpstring-str1-string-str2-string-encoding-int">strcasecmp</a>
+</td><td><a href="#strcmpstring-str1-string-str2-int">strcmp</a>
 </td><td><a href="#strcspnstring-str-string-char_list-int-offset-intnull-length-string-encoding-int">strcspn</a>
 </td><td><a href="#stringintintstringstring-intorhex-string">string</a>
-</td><td><a href="#string_has_bomstring-str-bool">string_has_bom</a>
-</td></tr><tr><td><a href="#strip_tagsstring-str-stringnull-allowable_tags-bool-clean_utf8-string">strip_tags</a>
+</td></tr><tr><td><a href="#string_has_bomstring-str-bool">string_has_bom</a>
+</td><td><a href="#strip_tagsstring-str-stringnull-allowable_tags-bool-clean_utf8-string">strip_tags</a>
 </td><td><a href="#strip_whitespacestring-str-string">strip_whitespace</a>
 </td><td><a href="#striposstring-haystack-string-needle-int-offset-string-encoding-bool-clean_utf8-falseint">stripos</a>
-</td><td><a href="#stripos_in_bytestring-haystack-string-needle-int-offset-falseint">stripos_in_byte</a>
-</td></tr><tr><td><a href="#stristrstring-haystack-string-needle-bool-before_needle-string-encoding-bool-clean_utf8-falsestring">stristr</a>
+</td></tr><tr><td><a href="#stripos_in_bytestring-haystack-string-needle-int-offset-falseint">stripos_in_byte</a>
+</td><td><a href="#stristrstring-haystack-string-needle-bool-before_needle-string-encoding-bool-clean_utf8-falsestring">stristr</a>
 </td><td><a href="#strlenstring-str-string-encoding-bool-clean_utf8-falseint">strlen</a>
 </td><td><a href="#strlen_in_bytestring-str-int">strlen_in_byte</a>
-</td><td><a href="#strnatcasecmpstring-str1-string-str2-string-encoding-int">strnatcasecmp</a>
-</td></tr><tr><td><a href="#strnatcmpstring-str1-string-str2-int">strnatcmp</a>
+</td></tr><tr><td><a href="#strnatcasecmpstring-str1-string-str2-string-encoding-int">strnatcasecmp</a>
+</td><td><a href="#strnatcmpstring-str1-string-str2-int">strnatcmp</a>
 </td><td><a href="#strncasecmpstring-str1-string-str2-int-len-string-encoding-int">strncasecmp</a>
 </td><td><a href="#strncmpstring-str1-string-str2-int-len-string-encoding-int">strncmp</a>
-</td><td><a href="#strpbrkstring-haystack-string-char_list-falsestring">strpbrk</a>
-</td></tr><tr><td><a href="#strposstring-haystack-intstring-needle-int-offset-string-encoding-bool-clean_utf8-falseint">strpos</a>
+</td></tr><tr><td><a href="#strpbrkstring-haystack-string-char_list-falsestring">strpbrk</a>
+</td><td><a href="#strposstring-haystack-intstring-needle-int-offset-string-encoding-bool-clean_utf8-falseint">strpos</a>
 </td><td><a href="#strpos_in_bytestring-haystack-string-needle-int-offset-falseint">strpos_in_byte</a>
 </td><td><a href="#strrchrstring-haystack-string-needle-bool-before_needle-string-encoding-bool-clean_utf8-falsestring">strrchr</a>
-</td><td><a href="#strrevstring-str-string-encoding-string">strrev</a>
-</td></tr><tr><td><a href="#strrichrstring-haystack-string-needle-bool-before_needle-string-encoding-bool-clean_utf8-falsestring">strrichr</a>
+</td></tr><tr><td><a href="#strrevstring-str-string-encoding-string">strrev</a>
+</td><td><a href="#strrichrstring-haystack-string-needle-bool-before_needle-string-encoding-bool-clean_utf8-falsestring">strrichr</a>
 </td><td><a href="#strriposstring-haystack-intstring-needle-int-offset-string-encoding-bool-clean_utf8-falseint">strripos</a>
 </td><td><a href="#strripos_in_bytestring-haystack-string-needle-int-offset-falseint">strripos_in_byte</a>
-</td><td><a href="#strrposstring-haystack-intstring-needle-int-offset-string-encoding-bool-clean_utf8-falseint">strrpos</a>
-</td></tr><tr><td><a href="#strrpos_in_bytestring-haystack-string-needle-int-offset-falseint">strrpos_in_byte</a>
+</td></tr><tr><td><a href="#strrposstring-haystack-intstring-needle-int-offset-string-encoding-bool-clean_utf8-falseint">strrpos</a>
+</td><td><a href="#strrpos_in_bytestring-haystack-string-needle-int-offset-falseint">strrpos_in_byte</a>
 </td><td><a href="#strspnstring-str-string-mask-int-offset-intnull-length-string-encoding-falseint">strspn</a>
 </td><td><a href="#strstrstring-haystack-string-needle-bool-before_needle-string-encoding-bool-clean_utf8-falsestring">strstr</a>
-</td><td><a href="#strstr_in_bytestring-haystack-string-needle-bool-before_needle-falsestring">strstr_in_byte</a>
-</td></tr><tr><td><a href="#strtocasefoldstring-str-bool-full-bool-clean_utf8-string-encoding-stringnull-lang-bool-lower-string">strtocasefold</a>
+</td></tr><tr><td><a href="#strstr_in_bytestring-haystack-string-needle-bool-before_needle-falsestring">strstr_in_byte</a>
+</td><td><a href="#strtocasefoldstring-str-bool-full-bool-clean_utf8-string-encoding-stringnull-lang-bool-lower-string">strtocasefold</a>
 </td><td><a href="#strtolowerstring-str-string-encoding-bool-clean_utf8-stringnull-lang-bool-try_to_keep_the_string_length-string">strtolower</a>
 </td><td><a href="#strtoupperstring-str-string-encoding-bool-clean_utf8-stringnull-lang-bool-try_to_keep_the_string_length-string">strtoupper</a>
-</td><td><a href="#strtrstring-str-stringstring-from-stringstring-to-string">strtr</a>
-</td></tr><tr><td><a href="#strwidthstring-str-string-encoding-bool-clean_utf8-int">strwidth</a>
+</td></tr><tr><td><a href="#strtrstring-str-stringstring-from-stringstring-to-string">strtr</a>
+</td><td><a href="#strwidthstring-str-string-encoding-bool-clean_utf8-int">strwidth</a>
 </td><td><a href="#substrstring-str-int-offset-intnull-length-string-encoding-bool-clean_utf8-falsestring">substr</a>
 </td><td><a href="#substr_comparestring-str1-string-str2-int-offset-intnull-length-bool-case_insensitivity-string-encoding-int">substr_compare</a>
-</td><td><a href="#substr_countstring-haystack-string-needle-int-offset-intnull-length-string-encoding-bool-clean_utf8-falseint">substr_count</a>
-</td></tr><tr><td><a href="#substr_count_in_bytestring-haystack-string-needle-int-offset-intnull-length-falseint">substr_count_in_byte</a>
+</td></tr><tr><td><a href="#substr_countstring-haystack-string-needle-int-offset-intnull-length-string-encoding-bool-clean_utf8-falseint">substr_count</a>
+</td><td><a href="#substr_count_in_bytestring-haystack-string-needle-int-offset-intnull-length-falseint">substr_count_in_byte</a>
 </td><td><a href="#substr_count_simplestring-str-string-substring-bool-case_sensitive-string-encoding-int">substr_count_simple</a>
 </td><td><a href="#substr_ileftstring-haystack-string-needle-string">substr_ileft</a>
-</td><td><a href="#substr_in_bytestring-str-int-offset-intnull-length-falsestring">substr_in_byte</a>
-</td></tr><tr><td><a href="#substr_irightstring-haystack-string-needle-string">substr_iright</a>
+</td></tr><tr><td><a href="#substr_in_bytestring-str-int-offset-intnull-length-falsestring">substr_in_byte</a>
+</td><td><a href="#substr_irightstring-haystack-string-needle-string">substr_iright</a>
 </td><td><a href="#substr_leftstring-haystack-string-needle-string">substr_left</a>
 </td><td><a href="#substr_replacestringstring-str-stringstring-replacement-intint-offset-intintnull-length-string-encoding-stringstring">substr_replace</a>
-</td><td><a href="#substr_rightstring-haystack-string-needle-string-encoding-string">substr_right</a>
-</td></tr><tr><td><a href="#swapcasestring-str-string-encoding-bool-clean_utf8-string">swapCase</a>
+</td></tr><tr><td><a href="#substr_rightstring-haystack-string-needle-string-encoding-string">substr_right</a>
+</td><td><a href="#swapcasestring-str-string-encoding-bool-clean_utf8-string">swapCase</a>
 </td><td><a href="#symfony_polyfill_used-bool">symfony_polyfill_used</a>
 </td><td><a href="#tabs_to_spacesstring-str-int-tab_length-string">tabs_to_spaces</a>
-</td><td><a href="#titlecasestring-str-string-encoding-bool-clean_utf8-stringnull-lang-bool-try_to_keep_the_string_length-string">titlecase</a>
-</td></tr><tr><td><a href="#to_asciistring-str-string-unknown-bool-strict-string">to_ascii</a>
+</td></tr><tr><td><a href="#titlecasestring-str-string-encoding-bool-clean_utf8-stringnull-lang-bool-try_to_keep_the_string_length-string">titlecase</a>
+</td><td><a href="#to_asciistring-str-string-unknown-bool-strict-string">to_ascii</a>
 </td><td><a href="#to_booleanboolfloatintstring-str-bool">to_boolean</a>
 </td><td><a href="#to_filenamestring-str-bool-use_transliterate-string-fallback_char-string">to_filename</a>
-</td><td><a href="#to_intstring-str-intnull">to_int</a>
-</td></tr><tr><td><a href="#to_iso8859stringstring-str-stringstring">to_iso8859</a>
+</td></tr><tr><td><a href="#to_intstring-str-intnull">to_int</a>
+</td><td><a href="#to_iso8859stringstring-str-stringstring">to_iso8859</a>
 </td><td><a href="#to_stringfloatintobjectstringnull-input-stringnull">to_string</a>
 </td><td><a href="#to_utf8stringstring-str-bool-decode_html_entity_to_utf8-stringstring">to_utf8</a>
-</td><td><a href="#to_utf8_stringstring-str-bool-decode_html_entity_to_utf8-string">to_utf8_string</a>
-</td></tr><tr><td><a href="#trimstring-str-stringnull-chars-string">trim</a>
+</td></tr><tr><td><a href="#to_utf8_stringstring-str-bool-decode_html_entity_to_utf8-string">to_utf8_string</a>
+</td><td><a href="#trimstring-str-stringnull-chars-string">trim</a>
 </td><td><a href="#ucfirststring-str-string-encoding-bool-clean_utf8-stringnull-lang-bool-try_to_keep_the_string_length-string">ucfirst</a>
 </td><td><a href="#ucwordsstring-str-string-exceptions-string-char_list-string-encoding-bool-clean_utf8-string">ucwords</a>
-</td><td><a href="#urldecodestring-str-bool-multi_decode-string">urldecode</a>
-</td></tr><tr><td><a href="#utf8_decodestring-str-bool-keep_utf8_chars-string">utf8_decode</a>
+</td></tr><tr><td><a href="#urldecodestring-str-bool-multi_decode-string">urldecode</a>
+</td><td><a href="#utf8_decodestring-str-bool-keep_utf8_chars-string">utf8_decode</a>
 </td><td><a href="#utf8_encodestring-str-string">utf8_encode</a>
 </td><td><a href="#whitespace_table-string">whitespace_table</a>
-</td><td><a href="#words_limitstring-str-int-limit-string-str_add_on-string">words_limit</a>
-</td></tr><tr><td><a href="#wordwrapstring-str-int-width-string-break-bool-cut-string">wordwrap</a>
+</td></tr><tr><td><a href="#words_limitstring-str-int-limit-string-str_add_on-string">words_limit</a>
+</td><td><a href="#wordwrapstring-str-int-width-string-break-bool-cut-string">wordwrap</a>
 </td><td><a href="#wordwrap_per_linestring-str-int-width-string-break-bool-cut-bool-add_final_break-stringnull-delimiter-string">wordwrap_per_line</a>
 </td><td><a href="#ws-string">ws</a>
 </td></tr></table>
@@ -555,7 +556,7 @@ Returns the character at $index, with indexes starting at 0.
 Returns an array consisting of the characters in the string.
 
 **Parameters:**
-- `T $str <p>The input string.</p>`
+- `string $str <p>The input string.</p>`
 
 **Return:**
 - `string[] <p>An array of chars.</p>`
@@ -618,7 +619,7 @@ Generates an array of byte length of each character of a Unicode string.
 EXAMPLE: <code>UTF8::chr_size_list('中文空白-test'); // [3, 3, 3, 3, 1, 1, 1, 1, 1]</code>
 
 **Parameters:**
-- `T $str <p>The original unicode string.</p>`
+- `string $str <p>The original unicode string.</p>`
 
 **Return:**
 - `int[] <p>An array of byte lengths of each character.</p>`
@@ -663,7 +664,7 @@ Splits a string into smaller chunks and multiple lines, using the specified line
 EXAMPLE: <code>UTF8::chunk_split('ABC-ÖÄÜ-中文空白-κόσμε', 3); // "ABC\r\n-ÖÄ\r\nÜ-中\r\n文空白\r\n-κό\r\nσμε"</code>
 
 **Parameters:**
-- `T $str <p>The original string to be split.</p>`
+- `string $str <p>The original string to be split.</p>`
 - `int<1, max> $chunk_length [optional] <p>The maximum character length of a chunk.</p>`
 - `string $end [optional] <p>The character(s) to be inserted at the end of each chunk.</p>`
 
@@ -732,7 +733,7 @@ UTF8::codepoints('κöñ', true); // array('U+03ba', 'U+00f6', 'U+00f1')
 </code>
 
 **Parameters:**
-- `T $arg <p>A UTF-8 encoded string or an array of such chars.</p>`
+- `string|string[] $arg <p>A UTF-8 encoded string or an array of such chars.</p>`
 - `bool $use_u_style <p>If True, will return code points in U+xxxx format,
 default, code points will be returned as integers.</p>`
 
@@ -766,7 +767,7 @@ Returns count of characters used in a string.
 EXAMPLE: <code>UTF8::count_chars('κaκbκc'); // array('κ' => 3, 'a' => 1, 'b' => 1, 'c' => 1)</code>
 
 **Parameters:**
-- `T $str <p>The input string.</p>`
+- `string $str <p>The input string.</p>`
 - `bool $clean_utf8 [optional] <p>Remove non UTF-8 chars from the string.</p>`
 - `bool $try_to_use_mb_functions [optional] <p>Set to false, if you don't want to use`
 
@@ -786,7 +787,7 @@ copy&past from https://github.com/drupal/core/blob/8.8.x/lib/Drupal/Component/Ut
 
 **Parameters:**
 - `string $str <p>INFO: if no identifier is given e.g. " " or "", we will create a unique string automatically</p>`
-- `array<string, string> $filter`
+- `string[] $filter`
 - `bool $strip_tags`
 - `bool $strtolower`
 
@@ -1036,7 +1037,7 @@ Normalizes to UTF-8 NFC, converting from WINDOWS-1252 when needed.
 EXAMPLE: <code>UTF8::filter(array("\xE9", 'à', 'a')); // array('é', 'à', 'a')</code>
 
 **Parameters:**
-- `TFilter $var`
+- `array|object|string $var`
 - `int $normalization_form`
 - `string $leading_combining`
 
@@ -1262,7 +1263,7 @@ __nothing__
 Returns the first $n characters of the string.
 
 **Parameters:**
-- `T $str <p>The input string.</p>`
+- `string $str <p>The input string.</p>`
 - `int<1, max> $n <p>Number of characters to retrieve from the start.</p>`
 - `string $encoding [optional] <p>Set the charset for e.g. "mb_" function</p>`
 
@@ -1313,7 +1314,7 @@ Fix a double (or multiple) encoded UTF8 string.
 EXAMPLE: <code>UTF8::fix_utf8('FÃÂÂÂÂ©dÃÂÂÂÂ©ration'); // 'Fédération'</code>
 
 **Parameters:**
-- `TFixUtf8 $str you can use a string or an array of strings`
+- `string|string[] $str you can use a string or an array of strings`
 
 **Return:**
 - `string|string[] <p>Will return the fixed input-"array" or
@@ -1356,7 +1357,7 @@ Get data from an array via array like string.
 EXAMPLE: <code>$array['foo'][123] = 'lall'; UTF8::getUrlParamFromArray('foo[123]', $array); // 'lall'</code>
 
 **Parameters:**
-- `string $param`
+- `array<array-key, mixed> $param`
 - `array<array-key, mixed> $data`
 
 **Return:**
@@ -1364,7 +1365,7 @@ EXAMPLE: <code>$array['foo'][123] = 'lall'; UTF8::getUrlParamFromArray('foo[123]
 
 --------
 
-## get_file_type(string $str, array $fallback): 
+## get_file_type(string $str, array{ext: null|string, mime: null|string, type: null|string} $fallback): array{ext: null|string, mime: null|string, type: null|string}
 <a href="#voku-php-readme-class-methods">↑</a>
 Warning: this method only works for some file-types (png, jpg)
          if you need more supported types, please use e.g. "finfo"
@@ -1374,7 +1375,7 @@ Warning: this method only works for some file-types (png, jpg)
 - `array{ext: (null|string), mime: (null|string), type: (null|string)} $fallback`
 
 **Return:**
-- `array{ext: (null|string), mime: (null|string), type: (null|string)}`
+- `array{ext: null|string, mime: null|string, type: null|string}`
 
 --------
 
@@ -1384,7 +1385,7 @@ Warning: this method only works for some file-types (png, jpg)
 
 **Parameters:**
 - `int<1, max> $length <p>Length of the random string.</p>`
-- `T $possible_chars [optional] <p>Characters string for the random selection.</p>`
+- `string $possible_chars [optional] <p>Characters string for the random selection.</p>`
 - `string $encoding [optional] <p>Set the charset for e.g. "mb_" function</p>`
 
 **Return:**
@@ -1482,7 +1483,7 @@ INFO: opposite to UTF8::html_decode()
 EXAMPLE: <code>UTF8::html_encode('中文空白'); // '&#20013;&#25991;&#31354;&#30333;'</code>
 
 **Parameters:**
-- `T $str <p>The Unicode string to be encoded as numbered entities.</p>`
+- `string $str <p>The Unicode string to be encoded as numbered entities.</p>`
 - `bool $keep_ascii_chars [optional] <p>Keep ASCII chars.</p>`
 - `string $encoding [optional] <p>Set the charset for e.g. "mb_" function</p>`
 
@@ -1508,7 +1509,7 @@ INFO: opposite to UTF8::html_encode()
 EXAMPLE: <code>UTF8::html_entity_decode('&#20013;&#25991;&#31354;&#30333;'); // '中文空白'</code>
 
 **Parameters:**
-- `T $str <p>
+- `string $str <p>
 The input string.
 </p>`
 - `int|null $flags [optional] <p>
@@ -1710,7 +1711,7 @@ INFO: Take a look at "UTF8::htmlentities()"
 EXAMPLE: <code>UTF8::htmlspecialchars('<白-öäü>'); // '&lt;白-öäü&gt;'</code>
 
 **Parameters:**
-- `T $str <p>
+- `string $str <p>
 The string being converted.
 </p>`
 - `int $flags [optional] <p>
@@ -2412,7 +2413,7 @@ EXAMPLE: <code>UTF8::normalize_encoding('UTF8'); // 'UTF-8'</code>
 
 **Parameters:**
 - `mixed $encoding <p>e.g.: ISO, UTF8, WINDOWS-1251 etc.</p>`
-- `string|TNormalizeEncodingFallback $fallback <p>e.g.: UTF-8</p>`
+- `mixed $fallback <p>e.g.: UTF-8</p>`
 
 **Return:**
 - `mixed|string <p>e.g.: ISO-8859-1, UTF-8, WINDOWS-1251 etc.<br>Will return a empty string as fallback (by default)</p>`
@@ -2562,7 +2563,7 @@ e.g:
 'D%25C3%2583%25C2%25BCsseldorf' => 'Düsseldorf'
 
 **Parameters:**
-- `T $str <p>The input string.</p>`
+- `string $str <p>The input string.</p>`
 - `bool $multi_decode <p>Decode as often as possible.</p>`
 
 **Return:**
@@ -2805,7 +2806,7 @@ Converts a UTF-8 character to HTML Numbered Entity like "&#123;".
 EXAMPLE: <code>UTF8::single_chr_html_encode('κ'); // '&#954;'</code>
 
 **Parameters:**
-- `T $char <p>The Unicode character to be encoded as numbered entity.</p>`
+- `string $char <p>The Unicode character to be encoded as numbered entity.</p>`
 - `bool $keep_ascii_chars <p>Set to <strong>true</strong> to keep ASCII chars.</>`
 - `string $encoding [optional] <p>Set the charset for e.g. "mb_" function</p>`
 
@@ -2819,7 +2820,7 @@ EXAMPLE: <code>UTF8::single_chr_html_encode('κ'); // '&#954;'</code>
 
 
 **Parameters:**
-- `T $str`
+- `string $str`
 - `int<1, max> $tab_length`
 
 **Return:**
@@ -2937,7 +2938,7 @@ UTF8::str_delimit('test -case', '**'); // 'test**case'
 </code>
 
 **Parameters:**
-- `T $str <p>The input string.</p>`
+- `string $str <p>The input string.</p>`
 - `string $delimiter <p>Sequence used to separate parts of the string.</p>`
 - `string $encoding [optional] <p>Set the charset for e.g. "mb_" function</p>`
 - `bool $clean_utf8 [optional] <p>Remove non UTF-8 chars from the string.</p>`
@@ -3010,7 +3011,7 @@ Ensures that the string begins with $substring. If it doesn't, it's
 prepended.
 
 **Parameters:**
-- `T $str <p>The input string.</p>`
+- `string $str <p>The input string.</p>`
 - `TSub $substring <p>The substring to add if not present.</p>`
 
 **Return:**
@@ -3023,7 +3024,7 @@ prepended.
 Ensures that the string ends with $substring. If it doesn't, it's appended.
 
 **Parameters:**
-- `T $str <p>The input string.</p>`
+- `string $str <p>The input string.</p>`
 - `TSub $substring <p>The substring to add if not present.</p>`
 
 **Return:**
@@ -3106,7 +3107,7 @@ Every replacement with search array is
 performed on the result of previous replacement.
 </p>`
 - `string|string[] $replacement <p>The replacement.</p>`
-- `TStrIReplaceSubject $subject <p>
+- `string|string[] $subject <p>
 If subject is an array, then the search and
 replace is performed with every entry of
 subject, and the return value is an array as
@@ -3289,7 +3290,7 @@ Returns the last $n characters of the string.
 Limit the number of characters in a string.
 
 **Parameters:**
-- `T $str <p>The input string.</p>`
+- `string $str <p>The input string.</p>`
 - `int<1, max> $length [optional] <p>Default: 100</p>`
 - `string $str_add_on [optional] <p>Default: …</p>`
 - `string $encoding [optional] <p>Set the charset for e.g. "mb_" function</p>`
@@ -3306,9 +3307,24 @@ Limit the number of characters in a string, but also after the next word.
 EXAMPLE: <code>UTF8::str_limit_after_word('fòô bàř fòô', 8, ''); // 'fòô bàř'</code>
 
 **Parameters:**
-- `T $str <p>The input string.</p>`
+- `string $str <p>The input string.</p>`
 - `int<1, max> $length [optional] <p>Default: 100</p>`
 - `string $str_add_on [optional] <p>Default: …</p>`
+- `string $encoding [optional] <p>Set the charset for e.g. "mb_" function</p>`
+
+**Return:**
+- `string`
+
+--------
+
+## str_limit_in_byte(string $str, int $length, string $str_add_on, string $encoding): string
+<a href="#voku-php-readme-class-methods">↑</a>
+Limit the number of characters in a string in bytes.
+
+**Parameters:**
+- `string $str <p>The input string.</p>`
+- `int<1, max> $length [optional] <p>Default: 100</p>`
+- `string $str_add_on [optional] <p>Default: ...</p>`
 - `string $encoding [optional] <p>Set the charset for e.g. "mb_" function</p>`
 
 **Return:**
@@ -3503,7 +3519,7 @@ Repeat a string.
 EXAMPLE: <code>UTF8::str_repeat("°~\xf0\x90\x28\xbc", 2); // '°~ð(¼°~ð(¼'</code>
 
 **Parameters:**
-- `T $str <p>
+- `string $str <p>
 The string to be repeated.
 </p>`
 - `int<1, max> $multiplier <p>
@@ -3586,7 +3602,7 @@ INFO: uses random algorithm which is weak for cryptography purposes
 EXAMPLE: <code>UTF8::str_shuffle('fòô bàř fòô'); // 'àòôřb ffòô '</code>
 
 **Parameters:**
-- `T $str <p>The input string</p>`
+- `string $str <p>The input string</p>`
 - `string $encoding [optional] <p>Set the charset for e.g. "mb_" function</p>`
 
 **Return:**
@@ -3825,7 +3841,7 @@ Surrounds $str with the given substring.
 
 **Parameters:**
 - `T $str`
-- `TSub $substring <p>The substring to add to both sides.</p>`
+- `string $substring <p>The substring to add to both sides.</p>`
 
 **Return:**
 - `string <p>A string with the substring both prepended and appended.</p>`
@@ -4021,7 +4037,7 @@ UTF8::str_word_count('中文空白 öäü ab#c', 2, '#'); // array(0 => '中文�
 
 **Parameters:**
 - `string $str <p>The input string.</p>`
-- `0|1|2 $format [optional] <p>
+- `int $format [optional] <p>
 <strong>0</strong> => return a number of words (default)<br>
 <strong>1</strong> => return an array of words<br>
 <strong>2</strong> => return an array of words with word-offset as key
@@ -4095,7 +4111,7 @@ INFO: opposite to UTF8::codepoints()
 EXAMPLE: <code>UTF8::string(array(246, 228, 252)); // 'öäü'</code>
 
 **Parameters:**
-- `int[]|numeric-string[]|int|numeric-string $intOrHex <p>Integer or Hexadecimal codepoints.</p>`
+- `int|int[]|string|string[] $intOrHex <p>Integer or Hexadecimal codepoints.</p>`
 
 **Return:**
 - `string <p>A UTF-8 encoded string.</p>`
@@ -4942,7 +4958,7 @@ EXAMPLE: <code>UTF8::substr_replace(array('Iñtërnâtiônàlizætiøn', 'foo'),
 source: https://gist.github.com/stemar/8287074
 
 **Parameters:**
-- `TSubReplace $str <p>The input string or an array of stings.</p>`
+- `string|string[] $str <p>The input string or an array of stings.</p>`
 - `string|string[] $replacement <p>The replacement string or an array of stings.</p>`
 - `int|int[] $offset <p>
 If start is positive, the replacing will begin at the start'th offset
@@ -5107,7 +5123,7 @@ Convert a string into "ISO-8859"-encoding (Latin-1).
 EXAMPLE: <code>UTF8::to_utf8(UTF8::to_iso8859('  -ABC-中文空白-  ')); // '  -ABC-????-  '</code>
 
 **Parameters:**
-- `TToIso8859 $str`
+- `string|string[] $str`
 
 **Return:**
 - `string|string[]`
@@ -5141,7 +5157,7 @@ case.</li>
 EXAMPLE: <code>UTF8::to_utf8(["\u0063\u0061\u0074"]); // array('cat')</code>
 
 **Parameters:**
-- `TToUtf8 $str <p>Any string or array of strings.</p>`
+- `string|string[] $str <p>Any string or array of strings.</p>`
 - `bool $decode_html_entity_to_utf8 <p>Set to true, if you need to decode html-entities.</p>`
 
 **Return:**
@@ -5163,7 +5179,7 @@ case.</li>
 EXAMPLE: <code>UTF8::to_utf8_string("\u0063\u0061\u0074"); // 'cat'</code>
 
 **Parameters:**
-- `T $str <p>Any string.</p>`
+- `string $str <p>Any string.</p>`
 - `bool $decode_html_entity_to_utf8 <p>Set to true, if you need to decode html-entities.</p>`
 
 **Return:**
@@ -5248,7 +5264,7 @@ e.g:
 'D%25C3%2583%25C2%25BCsseldorf' => 'Düsseldorf'
 
 **Parameters:**
-- `T $str <p>The input string.</p>`
+- `string $str <p>The input string.</p>`
 - `bool $multi_decode <p>Decode as often as possible.</p>`
 
 **Return:**


### PR DESCRIPTION
## Summary
- run composer install in build directory to get latest readme generator
- regenerate README via build script

## Testing
- `composer install` in build directory
- `php generate_docs.php`

------
https://chatgpt.com/codex/tasks/task_e_684d22b9b3708322a34ee0be904f9fe3

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/portable-utf8/226)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved type annotations and method signatures in the documentation for greater clarity and accuracy.
  - Added documentation for a new method to limit string length by byte count.
  - Made minor reordering and alignment adjustments in the method index table for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->