### PR TITLE
Fix docs typos

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,4 +11,4 @@ For example you can write me a email: lars@moelleken.org
 
 ## Known vulnerabilities
 
-Portable UTF-8 versions prior to 5.4.26 (released 2019-11-05) have an open redirect vulnerability. The `Bootup::filterRequestUri()` method used a unsecure `header('Location ...` implentation. And because it's most secure to not use this method at all, I decided to disable the function by default.
+Portable UTF-8 versions prior to 5.4.26 (released 2019-11-05) have an open redirect vulnerability. The `Bootup::filterRequestUri()` method used an insecure `header('Location ...` implementation. And because it's most secure to not use this method at all, I decided to disable the function by default.

--- a/build/docs/base.md
+++ b/build/docs/base.md
@@ -95,7 +95,7 @@ This removes any overhead from these polyfills as they are no longer part of you
 }
 ```
 
-##  Why Portable UTF-8?[]()
+## Why Portable UTF-8?
 PHP 5 and earlier versions have no native Unicode support. To bridge the gap, there exist several extensions like "mbstring", "iconv" and "intl".
 
 The problem with "mbstring" and others is that most of the time you cannot ensure presence of a specific one on a server. If you rely on one of these, your application is no more portable. This problem gets even severe for open source applications that have to run on different servers with different configurations. Considering these, I decided to write a library:

--- a/src/voku/helper/UTF8.php
+++ b/src/voku/helper/UTF8.php
@@ -1108,7 +1108,7 @@ final class UTF8
      *
      * EXAMPLE: <code>UTF8::css_identifier('123foo/bar!!!'); // _23foo-bar</code>
      *
-     * copy&past from https://github.com/drupal/core/blob/8.8.x/lib/Drupal/Component/Utility/Html.php#L95
+     * copy&paste from https://github.com/drupal/core/blob/8.8.x/lib/Drupal/Component/Utility/Html.php#L95
      *
      * @param string   $str        <p>INFO: if no identifier is given e.g. " " or "", we will create a unique string automatically</p>
      * @param string[] $filter
@@ -3086,7 +3086,7 @@ final class UTF8
     }
 
     /**
-     * Create a escape html version of the string via "UTF8::htmlspecialchars()".
+     * Create an escaped HTML version of the string via `UTF8::htmlspecialchars()`.
      *
      * @param string $str
      * @param string $encoding [optional] <p>Set the charset for e.g. "mb_" function</p>
@@ -5303,7 +5303,7 @@ final class UTF8
      *
      * EXAMPLE: <code>UTF8::remove_invisible_characters("κόσ\0με"); // 'κόσμε'</code>
      *
-     * copy&past from https://github.com/bcit-ci/CodeIgniter/blob/develop/system/core/Common.php
+     * copy&paste from https://github.com/bcit-ci/CodeIgniter/blob/develop/system/core/Common.php
      *
      * @param string $str                           <p>The input string.</p>
      * @param bool   $url_encoded                   [optional] <p>
@@ -13363,7 +13363,7 @@ final class UTF8
      *
      * @param string      $str        <p>The input string.</p>
      * @param int<1, max> $limit      <p>The limit of words as integer.</p>
-     * @param string      $str_add_on <p>Replacement for the striped string.</p>
+     * @param string      $str_add_on <p>Replacement for the stripped string.</p>
      *
      * @psalm-pure
      *


### PR DESCRIPTION
## Summary
- fix vulnerabilities note in SECURITY.md
- correct heading in docs generator base
- clarify `html_escape` phpdoc
- revert README edits since it's auto-generated

## Testing
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_684d4b7223e0832296595a30763ba17e

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/portable-utf8/227)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected typographical errors and improved grammar in security documentation.
  - Fixed formatting issue in documentation headers for improved readability.
  - Updated comments and docblocks to correct minor typos and enhance clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->